### PR TITLE
closes #64 声優のカテゴリ取得APIの上限を500件に緩和する

### DIFF
--- a/lib/tasks/seiyu_parser.ex
+++ b/lib/tasks/seiyu_parser.ex
@@ -19,6 +19,6 @@ defmodule SeiyuWatch.SeiyuParser do
   end
 
   def wikipedia_page_request(name) do
-    "https://ja.wikipedia.org/w/api.php?format=json&action=query&prop=revisions|categories|info&titles=#{URI.encode(name)}&rvprop=sha1|ids&inprop=url"
+    "https://ja.wikipedia.org/w/api.php?format=json&action=query&prop=revisions|categories|info&titles=#{URI.encode(name)}&rvprop=sha1|ids&inprop=url&cllimit=500"
   end
 end


### PR DESCRIPTION
カテゴリが10件までしか取得できていなかったので，運良くその10件に声優カテゴリが入っている人だけしか登録できなかったようで．